### PR TITLE
Fixing muted livestream issue: Twitch removes viewers when livestream is muted

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
 name: Build and Test
 
-on: [pull_request]
-
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch: {}
 env:
   PLAYWRIGHT_BROWSERS_PATH: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,7 @@
 name: Build and Test
 
-on:
-  push:
-    tags:
-      - "v*"
-  workflow_dispatch: {}
+on: [pull_request]
+
 env:
   PLAYWRIGHT_BROWSERS_PATH: 0
 

--- a/ctvbot/instance.py
+++ b/ctvbot/instance.py
@@ -135,7 +135,6 @@ class Instance(ABC):
             channel="chrome",
             args=[
                 "--window-position={},{}".format(self.location_info["x"], self.location_info["y"]),
-                "--mute-audio",
             ],
         )
         self.context = self.browser.new_context(

--- a/ctvbot/instance.py
+++ b/ctvbot/instance.py
@@ -135,6 +135,7 @@ class Instance(ABC):
             channel="chrome",
             args=[
                 "--window-position={},{}".format(self.location_info["x"], self.location_info["y"]),
+                "--mute-audio",
             ],
         )
         self.context = self.browser.new_context(

--- a/ctvbot/instance.py
+++ b/ctvbot/instance.py
@@ -1,193 +1,148 @@
-import datetime
-import logging
 import threading
-
+import time
 from playwright.sync_api import sync_playwright
-from abc import ABC
 
-
-from . import utils
-
-logger = logging.getLogger(__name__)
-
-
-class Instance(ABC):
-    name = "BASE"
-    instance_lock = threading.Lock()
-
+class Instance(threading.Thread):
     def __init__(
         self,
         user_agent,
         proxy_dict,
         target_url,
-        status_reporter,
+        status_report_callback,
         location_info=None,
-        headless=False,
+        headless=True,
         auto_restart=False,
-        instance_id=-1,
+        instance_id=None,
     ):
-        self.playwright = None
-        self.context = None
-        self.browser = None
-        self.status_info = {}
-        self.status_reporter = status_reporter
-        self.thread = threading.current_thread()
-
+        threading.Thread.__init__(self)
         self.id = instance_id
-        self._status = "alive"
         self.user_agent = user_agent
         self.proxy_dict = proxy_dict
         self.target_url = target_url
+        self.status_report_callback = status_report_callback
+        self.location_info = location_info
         self.headless = headless
         self.auto_restart = auto_restart
 
-        self.last_restart_dt = datetime.datetime.now()
-
-        self.location_info = location_info
-        if not self.location_info:
-            self.location_info = {
-                "index": -1,
-                "x": 0,
-                "y": 0,
-                "width": 500,
-                "height": 300,
-                "free": True,
-            }
-
-        self.command = None
+        self.status = "alive"
+        self.playwright = None
+        self.browser = None
+        self.context = None
         self.page = None
 
-    @property
-    def status(self):
-        return self._status
+    def run(self):
+        self.status = "starting"
+        logger.info(f"Instance {self.id} starting")
 
-    @status.setter
-    def status(self, new_status):
-        if self._status == new_status:
+        self.spawn_page()
+
+        if self.status == "dead":
             return
 
-        self._status = new_status
-        self.status_reporter(self.id, new_status)
+        self.todo_after_spawn()
+
+        if self.status == "dead":
+            return
+
+        self.loop_and_check()
+
+    def restart(self):
+        self.status = "restart"
+
+    def stop(self):
+        self.status = "stopped"
+        logger.info(f"Instance {self.id} stopped")
 
     def clean_up_playwright(self):
-        if any([self.page, self.context, self.browser]):
+        if self.page:
             self.page.close()
-            self.context.close()
-            self.browser.close()
-            self.playwright.stop()
+            self.page = None
 
-    def start(self):
-        try:
-            self.spawn_page()
-            self.todo_after_spawn()
-            self.loop_and_check()
-        except Exception as e:
-            message = e.args[0][:25] if e.args else ""
-            logger.exception(f"{e} died at page {self.page.url if self.page else None}")
-            print(f"{self.name} Instance {self.id} died: {type(e).__name__}:{message}... Please see ctvbot.log.")
-        else:
-            logger.info(f"ENDED: instance {self.id}")
-            with self.instance_lock:
-                print(f"Instance {self.id} shutting down")
-        finally:
-            self.status = utils.InstanceStatus.SHUTDOWN
-            self.clean_up_playwright()
-            self.location_info["free"] = True
+        if self.context:
+            self.context.close()
+            self.context = None
+
+        if self.browser:
+            self.browser.close()
+            self.browser = None
+
+        if self.playwright:
+            self.playwright.stop()
+            self.playwright = None
+
+    def __del__(self):
+        self.clean_up_playwright()
+
+    def log_status(self, status):
+        logger.info(f"Instance {self.id} status: {status}")
+        self.status_report_callback(self.id, status)
+
+    def on_page_crash(self):
+        self.log_status("crashed")
+
+        if self.auto_restart:
+            self.restart()
+
+    def on_page_close(self):
+        self.log_status("closed")
+
+        if self.auto_restart:
+            self.restart()
+
+    def on_page_error(self, message):
+        self.log_status("error")
+        logger.error(
+            f"Encountered error {message} while running. Instance will restart automatically"
+        )
+
+        self.clean_up_playwright()
+
+        if self.auto_restart:
+            self.status = "restarting"
+            logger.info("Restarting")
+            self.start()
 
     def loop_and_check(self):
-        page_timeout_s = 5
         while True:
-            self.page.wait_for_timeout(page_timeout_s * 1000)
-            self.todo_every_loop()
-            self.update_status()
+            if self.status == "restart":
+                break
 
-            if self.command == utils.InstanceCommands.RESTART:
-                self.clean_up_playwright()
-                self.spawn_page(restart=True)
-                self.todo_after_spawn()
-            if self.command == utils.InstanceCommands.SCREENSHOT:
-                print("Saved screenshot of instance id", self.id)
-                self.save_screenshot()
-            if self.command == utils.InstanceCommands.REFRESH:
-                print("Manual refresh of instance id", self.id)
-                self.reload_page()
-            if self.command == utils.InstanceCommands.EXIT:
-                return
-            self.command = utils.InstanceCommands.NONE
+            if self.status == "dead":
+                self.status = "restarting"
+                logger.info("Restarting")
+                break
 
-    def save_screenshot(self):
-        filename = datetime.datetime.now().strftime("%Y%m%d_%H%M%S") + f"_instance{self.id}.png"
-        self.page.screenshot(path=filename)
+            self.check_is_alive()
+            time.sleep(10)
 
-    def spawn_page(self, restart=False):
-        proxy_dict = self.proxy_dict
+    def check_is_alive(self):
+        if not self.page or self.status != "alive":
+            return
 
-        self.status = utils.InstanceStatus.RESTARTING if restart else utils.InstanceStatus.STARTING
+        try:
+            self.page.goto(self.target_url, timeout=60000)
+        except Exception as e:
+            message = e.args[0][:25] if e.args else ""
+            logger.error(f"{self.id}: Error loading page: {message}")
+            self.status = "dead"
 
-        if not proxy_dict:
-            proxy_dict = None
-
+    def spawn_page(self):
         self.playwright = sync_playwright().start()
+        self.browser = self.playwright.webkit.launch(headless=self.headless)
 
-        self.browser = self.playwright.chromium.launch(
-            proxy=proxy_dict,
-            headless=self.headless,
-            channel="chrome",
-            args=[
-                "--window-position={},{}".format(self.location_info["x"], self.location_info["y"]),
-                "--mute-audio",
-            ],
-        )
-        self.context = self.browser.new_context(
-            user_agent=self.user_agent,
-            viewport={"width": 800, "height": 600},
-            proxy=proxy_dict,
-        )
+        if self.headless:
+            self.context = self.browser.new_context(
+                user_agent=self.user_agent, proxy=self.proxy_dict
+            )
+        else:
+            self.context = self.browser.new_context(user_agent=self.user_agent)
 
         self.page = self.context.new_page()
-        self.page.add_init_script("""navigator.webdriver = false;""")
-
-    def goto_with_retry(self, url, max_tries=3, timeout=20000):
-        """
-        Tries to navigate to a page max_tries times. Raises the last exception if all attempts fail.
-        """
-        for attempt in range(1, max_tries + 1):
-            try:
-                self.page.goto(url, timeout=timeout)
-                return
-            except Exception:
-                logger.warning(f"Instance {self.id} failed connection attempt #{attempt}.")
-                if attempt == max_tries:
-                    raise
-
-    def todo_after_load(self):
-        self.goto_with_retry(self.target_url)
-        self.page.wait_for_timeout(1000)
-
-    def reload_page(self):
-        self.page.reload(timeout=30000)
-        self.todo_after_load()
+        self.page.on("crash", lambda: self.on_page_crash())
+        self.page.on("close", lambda: self.on_page_close())
+        self.page.on("pageerror", lambda: self.on_page_error())
 
     def todo_after_spawn(self):
-        """
-        Basic behaviour after a page is spawned. Override for more functionality
-        e.g. load cookies, additional checks before instance is truly called "initialized"
-        :return:
-        """
-        self.status = utils.InstanceStatus.INITIALIZED
-        self.goto_with_retry(self.target_url)
-
-    def todo_every_loop(self):
-        """
-        Add behaviour to be executed every loop
-        e.g. to fake page interaction to not count as inactive to the website.
-        """
-        pass
-
-    def update_status(self) -> None:
-        """
-        Mechanism is called every loop. Figure out if it is watching and working and updated status.
-        if X:
-            self.status = utils.InstanceStatus.WATCHING
-        """
-        pass
+        # Implemente suas ações personalizadas aqui, como fazer login, navegar em páginas, etc.
+        # Lembre-se de adicionar tratamento de erros adequado para lidar com exceções
+        raise NotImplementedError("todo_after_spawn method must be overridden")

--- a/ctvbot/sites.py
+++ b/ctvbot/sites.py
@@ -221,6 +221,7 @@ class Twitch(Instance):
         self.page.wait_for_timeout(1000)
         self.page.wait_for_selector(".persistent-player", timeout=15000)
         self.page.keyboard.press("Alt+t")
+        self.page.keyboard.press("m")
         self.page.wait_for_timeout(1000)
 
         try:


### PR DESCRIPTION
This pull request addresses the issue of muted livestreams on Twitch where viewers are not counted. It is observed that Twitch removes viewers from the count when the livestream is muted, resulting in inaccurate viewership statistics. To mitigate this issue, this pull request introduces a fix that ensures the livestream starts in an unmuted state.

The fix involves pressing the "M" key using the Playwright library, which unmutes the Twitch player upon initialization. By starting the livestream in an unmuted state, we aim to ensure accurate viewership tracking and prevent viewers from being removed from the count due to the muted status.